### PR TITLE
GOOGLE_APP_TOKENの削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 ```.env
 GOOGLE_CLIENT_ID="(Google Cloud Consoleから取得してください)"
 GOOGLE_CLIENT_SECRET="(Google Cloud Consoleから取得してください)"
-GOOGLE_API_TOKEN="(Google Cloud Consoleから取得してください)"
 GOOGLE_ACCESS_TOKEN="(authorize.jsを実行して取得してください)"
 GOOGLE_REFRESH_TOKEN="(authorize.jsを実行して取得してください)"
 GOOGLE_CALENDAR_ID="(ご自身のGoogle CalendarのカレンダーIDを貼り付けてください)"

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,7 +5,6 @@ export const getEnv = () =>
   const {
     GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET,
-    GOOGLE_API_TOKEN,
     GOOGLE_ACCESS_TOKEN,
     GOOGLE_REFRESH_TOKEN,
     GOOGLE_CALENDAR_ID,
@@ -16,9 +15,6 @@ export const getEnv = () =>
   }
   if (!GOOGLE_CLIENT_SECRET) {
     throw Error('Please set the environment variable GOOGLE_CLIENT_SECRET.');
-  }
-  if (!GOOGLE_API_TOKEN) {
-    throw Error('Please set the environment variable GOOGLE_API_TOKEN.');
   }
   if (!GOOGLE_ACCESS_TOKEN) {
     throw Error('Please set the environment variable GOOGLE_ACCESS_TOKEN.');
@@ -33,7 +29,6 @@ export const getEnv = () =>
   return {
     googleClientID: GOOGLE_CLIENT_ID,
     googleClientSecret: GOOGLE_CLIENT_SECRET,
-    googleApiToken: GOOGLE_API_TOKEN,
     googleAccessToken: GOOGLE_ACCESS_TOKEN,
     googleRefreshToken: GOOGLE_REFRESH_TOKEN,
     googleCalendarID: GOOGLE_CALENDAR_ID,


### PR DESCRIPTION
## 理由
- 不要であるため（処理に一切使用していない）